### PR TITLE
Fix brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository is used for:
 ## Using [Homebrew](https://brew.sh)
 ```
 brew tap melonamin/formulae
-brew cask install esse
+brew install --cask esse
 ```
 ### Download
 


### PR DESCRIPTION
> ❯ brew cask install esse
> Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.